### PR TITLE
NixOS: do not import minimal profile

### DIFF
--- a/builders/nixos/setup.sh
+++ b/builders/nixos/setup.sh
@@ -2,7 +2,6 @@ cat <<EOF > /etc/nixos/configuration.nix
 { config, pkgs, ... }:
 {
   imports = [
-    <nixpkgs/nixos/modules/profiles/minimal.nix>
     <nixpkgs/nixos/modules/virtualisation/container-config.nix>
     <nixpkgs/nixos/modules/installer/cd-dvd/channel.nix>
     ./build.nix


### PR DESCRIPTION
The [environment.noXlibs = true](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/profiles/minimal.nix#L9) seems cause a lot of large rebuilds (libsvg, java, ...) making the overall experience a lot worse. Documentation is nice too.

Maybe this should be reported upstream?